### PR TITLE
Fixed issue of classloading resources in external projects.

### DIFF
--- a/src/main/scala/de/sorted/chaos/wavefront/utilities/FileReader.scala
+++ b/src/main/scala/de/sorted/chaos/wavefront/utilities/FileReader.scala
@@ -9,7 +9,7 @@ object FileReader {
   private final val Log = LoggerFactory.getLogger(this.getClass)
 
   def read(filename: String): Vector[String] = {
-    val maybeStream = Try(this.getClass.getResourceAsStream(filename))
+    val maybeStream = Try(this.getClass.getClassLoader.getResourceAsStream(filename))
     maybeStream match {
       case Failure(exception) =>
         Log.error(


### PR DESCRIPTION
When not using class loader resources will just be loaded from library project and not classpath.